### PR TITLE
Adding config for weird dependency issue and gitignore consolidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-# was using some jetbrains stuff and 
+# was using some jetbrains stuff and
 # had to put an ignore at this level
 .idea/*
+.vscode/launch.json
+config

--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,1 +1,0 @@
-launch.json


### PR DESCRIPTION
The dependency `config` has a weird issue when trying to debug the `back-end` project where it will require a config folder in the root project so adding that to the root gitignore file and consolidating.