### PR TITLE
Hide mapping of source files

### DIFF
--- a/back-end/controllers/user.js
+++ b/back-end/controllers/user.js
@@ -7,7 +7,7 @@ router.get("/user/:userId", async function (req, res, next) {
   try {
     const userId = req.params["userId"];
 
-    const query = `SELECT username, secret
+    const query = `SELECT secret
       FROM Users u INNER JOIN Secrets s
       ON u.user_id = s.user
       WHERE u.user_id = ${userId}`;

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -20,6 +20,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "cleanBuild": "rimraf ./build/*",
+    "build-prod": "npm run cleanBuild && set \"GENERATE_SOURCEMAP=false\" && react-scripts build ",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/front-end/src/components/AddSecretsModal.js
+++ b/front-end/src/components/AddSecretsModal.js
@@ -41,8 +41,6 @@ const AddSecretsModal = ({ userId, secretUpdate, secretUpdateCount }) => {
 
   const handleAdd = () => {
     setOpen(false);
-    console.log(userId);
-    console.log(secret);
 
     const newSecret = new URLSearchParams();
     newSecret.append('secret', secret);

--- a/front-end/src/components/Register.js
+++ b/front-end/src/components/Register.js
@@ -37,10 +37,10 @@ const Register = () => {
   const handleRegister = (e) => {
     e.preventDefault();
     const { username, password } = e.target.elements;
-    const md5Psw = CryptoJS.MD5(password.value).toString(CryptoJS.enc.Hex);
+    const hashedPwd = CryptoJS.SHA512(password.value).toString(CryptoJS.enc.Hex);
     const payload = {
       username: username.value,
-      password: md5Psw,
+      password: hashedPwd,
     };
 
     const config = {

--- a/front-end/src/components/SignIn.js
+++ b/front-end/src/components/SignIn.js
@@ -42,11 +42,11 @@ const SignIn = (props) => {
   const handleLogin = (e) => {
     e.preventDefault();
     const { username, password } = e.target.elements;
-    const md5Psw = CryptoJS.MD5(password.value).toString(CryptoJS.enc.Hex);
+    const hashedPwd = CryptoJS.SHA512(password.value).toString(CryptoJS.enc.Hex);
 
     const loginCreds = new URLSearchParams();
     loginCreds.append('username', username.value);
-    loginCreds.append('password', md5Psw);
+    loginCreds.append('password', hashedPwd);
 
     const config = {
       headers: {


### PR DESCRIPTION
Setting \"GENERATE_SOURCEMAP=false\" will hide the files in developer tools. Will be used specifically for production builds

Before:
![Capture](https://user-images.githubusercontent.com/13741212/108149368-af1e2a00-70a0-11eb-90f4-0ca0e34b5e7c.PNG)


After:
![Capture](https://user-images.githubusercontent.com/13741212/108149296-839b3f80-70a0-11eb-91b6-4b6ac0774892.PNG)
