### PR TITLE
Salt passwords

### DIFF
--- a/back-end/controllers/user.js
+++ b/back-end/controllers/user.js
@@ -3,11 +3,10 @@ const router = express.Router();
 const { queryDB } = require("../helpers/db-helpers");
 
 router.get("/user/:userId", async function (req, res, next) {
-  // will return {'username': 'sample', 'secret': 'sample} for given userid
   try {
     const userId = req.params["userId"];
 
-    const query = `SELECT secret
+    const query = `SELECT secret_id, secret
       FROM Users u INNER JOIN Secrets s
       ON u.user_id = s.user
       WHERE u.user_id = ${userId}`;
@@ -38,6 +37,25 @@ router.post("/user/secret", async function (req, res) {
       return res.status(200).send("SUCCESS");
     } else {
       return res.status(401).send("401");
+    }
+  } catch (err) {
+    console.log("user.js API ERROR:", err);
+    res.status(500).send(err);
+  }
+});
+
+router.delete("/delete-secret/:secretId", async function (req, res) {
+  try {
+    const secretId = req.params["secretId"];
+
+    const query = `DELETE from Secrets WHERE secret_id = ${secretId}`;
+
+    const results = await queryDB(query);
+
+    if (results.affectedRows != 1) {
+      return res.status(400).send("Something wrong");
+    } else {
+      return res.status(200).send("deleted");
     }
   } catch (err) {
     console.log("user.js API ERROR:", err);

--- a/back-end/controllers/user.js
+++ b/back-end/controllers/user.js
@@ -12,12 +12,7 @@ router.get("/user/:userId", async function (req, res, next) {
       WHERE u.user_id = ${userId}`;
 
     const results = await queryDB(query);
-
-    if (results.length <= 0) {
-      return res.status(401).send("Not found.");
-    } else {
-      return res.status(200).send(results);
-    }
+    res.status(200).send(results);
   } catch (err) {
     console.log("user.js API ERROR:", err);
     res.status(500).send(err);

--- a/back-end/database/db.sql
+++ b/back-end/database/db.sql
@@ -3,6 +3,7 @@ CREATE TABLE Users (
   user_id INT NOT NULL AUTO_INCREMENT,
   username VARCHAR(255) UNIQUE,
   password VARCHAR(255),
+  salt VARCHAR(255),
   PRIMARY KEY (user_id)
 );
 
@@ -14,13 +15,23 @@ CREATE TABLE Secrets (
   FOREIGN KEY (user) REFERENCES Users(user_id)
 );
 
-INSERT INTO Users (username, password)
+INSERT INTO Users (username, password, salt)
 VALUES
-  ("admin", "password"),
-  ("bob8", "p@ssw0rd"),
-  ("andreP3000", "3l!teHaxor"),
-  ("shyltontor123", "Brazillionaire"),
-  ("chungusamongus", "password123");
+  ("admin",
+  "97d0ff0c7c8a9a4583772c9ea405314c33aa5465355c952f55f2d4983f6306dd8e7c3c96e09e6b6712775352e952c7afabf860731651644f8b5e36cdd9113880",
+  "samplesalt1"),
+  ("bob8",
+  "7839f3f7470781786fab51975c6dcdd27b1f668cb793219d0c04f223b186f9db829a55f53493ca8861eda7d05a54ef71ce83b04970ca7ad2ddc0f925b8dfa951",
+  "samplesalt2"),
+  ("andreP3000",
+  "7b12d79bfcd0c090009fc90abadf0997aa2c40b4d12643e8099327c7ebb0b9bb590d8c214eb0dcae39f6a7dae901aa5b46649a81d13120282778dfc1151fb929",
+  "samplesalt3"),
+  ("shyltontor123",
+  "1223054f48eca3b0a7578a191eac38b10eb6bca83d524ab75d96be4d26b25ecf0be9eff4b8e3fcbf69664a9b1b9f337bc9793d1bae2490bc1f86c0c497dac1f8",
+  "samplesalt4"),
+  ("chungusamongus",
+  "bcfc1ec2ed1a76ed05d891b6fda491dbf18f0234cccc409ddcc8761376a569918da24e52913073fa31c5ec0832233c2134f4fc505fab211880a9d28f86ec51ae",
+  "samplesalt5");
 
 INSERT INTO Secrets (secret, user)
 VALUES

--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -12,6 +12,7 @@
         "body-parser": "^1.19.0",
         "config": "^3.3.3",
         "cors": "^2.8.5",
+        "crypto-js": "^4.0.0",
         "express": "^4.17.1",
         "mariadb": "^2.5.2"
       }
@@ -125,6 +126,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -711,6 +717,11 @@
         "object-assign": "^4",
         "vary": "^1"
       }
+    },
+    "crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "debug": {
       "version": "2.6.9",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -13,6 +13,7 @@
     "body-parser": "^1.19.0",
     "config": "^3.3.3",
     "cors": "^2.8.5",
+    "crypto-js": "^4.0.0",
     "express": "^4.17.1",
     "mariadb": "^2.5.2"
   }

--- a/front-end/src/components/Register.js
+++ b/front-end/src/components/Register.js
@@ -61,7 +61,9 @@ const Register = () => {
       })
       .catch((error) => {
         console.log(error);
-        if (error.response.status === 400) {
+        if (!error.status) {
+          console.log('Network error.');
+        } else if (error.response.status === 400) {
           setusernameInUse(true);
           setregisterSuccess(false);
           setserverError(false);

--- a/front-end/src/components/Register.js
+++ b/front-end/src/components/Register.js
@@ -37,10 +37,11 @@ const Register = () => {
   const handleRegister = (e) => {
     e.preventDefault();
     const { username, password } = e.target.elements;
-    const hashedPwd = CryptoJS.SHA512(password.value).toString(CryptoJS.enc.Hex);
+    const salt = CryptoJS.lib.WordArray.random(16).toString();
     const payload = {
       username: username.value,
-      password: hashedPwd,
+      password: password.value,
+      salt,
     };
 
     const config = {
@@ -61,9 +62,7 @@ const Register = () => {
       })
       .catch((error) => {
         console.log(error);
-        if (!error.status) {
-          console.log('Network error.');
-        } else if (error.response.status === 400) {
+        if (error.response.status === 400) {
           setusernameInUse(true);
           setregisterSuccess(false);
           setserverError(false);

--- a/front-end/src/components/SignIn.js
+++ b/front-end/src/components/SignIn.js
@@ -64,7 +64,9 @@ const SignIn = (props) => {
         }
       })
       .catch((err) => {
-        if (err.response.status === 401) {
+        if (!err.status) {
+          console.log('Network error.');
+        } else if (err.response.status === 401) {
           console.log('Invalid credentials');
           props.signInAttempt(true);
         } else {

--- a/front-end/src/components/SignIn.js
+++ b/front-end/src/components/SignIn.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import CryptoJS from 'crypto-js';
 
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
@@ -39,11 +38,9 @@ const SignIn = (props) => {
   const handleLogin = (e) => {
     e.preventDefault();
     const { username, password } = e.target.elements;
-    const hashedPwd = CryptoJS.SHA512(password.value).toString(CryptoJS.enc.Hex);
-
     const loginCreds = new URLSearchParams();
     loginCreds.append('username', username.value);
-    loginCreds.append('password', hashedPwd);
+    loginCreds.append('password', password.value);
 
     const config = {
       headers: {
@@ -64,9 +61,7 @@ const SignIn = (props) => {
         }
       })
       .catch((err) => {
-        if (!err.status) {
-          console.log('Network error.');
-        } else if (err.response.status === 401) {
+        if (err.response.status === 401) {
           console.log('Invalid credentials');
           props.signInAttempt(true);
         } else {

--- a/front-end/src/components/User.js
+++ b/front-end/src/components/User.js
@@ -60,7 +60,7 @@ const User = (props) => {
       .delete(`${process.env.REACT_APP_BACKEND_SERVICE}/delete-secret/${secretId}`)
       .then((res) => {
         if (res.status === 200) {
-          getAllSecrets(); // re-render the page
+          setSecretUpdate(secretUpdate - 1); // re-render the page
         }
       })
       .catch((err) => {

--- a/front-end/src/components/User.js
+++ b/front-end/src/components/User.js
@@ -8,6 +8,8 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
+import IconButton from '@material-ui/core/IconButton';
+import DeleteIcon from '@material-ui/icons/Delete';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
@@ -54,6 +56,19 @@ const User = (props) => {
     getAllSecrets();
   }, [secretUpdate]);
 
+  const deleteSecret = (secretId) => {
+    axios
+      .delete(`${process.env.REACT_APP_BACKEND_SERVICE}/delete-secret/${secretId}`)
+      .then((res) => {
+        if (res.status === 200) {
+          getAllSecrets(); // re-render the page
+        }
+      })
+      .catch((err) => {
+        console.log(`Error on delete: ${err}`);
+      });
+  };
+
   return (
     <Container component="main" maxWidth="xs" className={classes.buttons}>
       <Box mb={3}>
@@ -74,6 +89,11 @@ const User = (props) => {
               <TableRow key={row.secret}>
                 <TableCell component="th" scope="row">
                   {row.secret}
+                </TableCell>
+                <TableCell>
+                  <IconButton onClick={() => deleteSecret(row.secret_id)}>
+                    <DeleteIcon />
+                  </IconButton>
                 </TableCell>
               </TableRow>
             ))}

--- a/front-end/src/components/User.js
+++ b/front-end/src/components/User.js
@@ -43,7 +43,6 @@ const User = (props) => {
       .get(`${process.env.REACT_APP_BACKEND_SERVICE}/user/${userId}`)
       .then((res) => {
         if (res.status === 200) {
-          // const allSecrets = res.data;
           setSecrets(res.data);
         }
       })


### PR DESCRIPTION
Just to clarify, the new flow from these changes is: 

* On register, generate a random string for a salt. 
* On backend, the plain password is concatenated with salt, then hashed and stored. Both the hashed password and salt are stored in DB.
* On login, just plain password is sent in login POST request. On receiving request, backend queries DB for hashed password and salt. 
* Backend does same concatenation with plain password and salt, hashes it, then compares to DB field.

(Note: this was opened after #33 so I merged those commits in. Once that PR is merged I'll rebase.)